### PR TITLE
add event sink to be able to play back events

### DIFF
--- a/lib/MessageBus.mjs
+++ b/lib/MessageBus.mjs
@@ -1,8 +1,9 @@
 import EventEmitter from 'eventemitter3';
 import Event from './Event';
+import Sink from './Sink';
 import { toKey } from './utils';
 
-function getGlobal() {
+function getGlobalThis() {
     if (typeof window !== 'undefined') {
         return window;
     }
@@ -12,24 +13,34 @@ function getGlobal() {
     throw new Error('unable to locate global object');
 }
 
-function getEventEmitter() {
-    let ee = getGlobal()['@podium'];
-    if (!ee) {
-        ee = new EventEmitter();
-        getGlobal()['@podium'] = ee;
+function getGlobalObjects() {
+    let objs = getGlobalThis()['@podium'];
+    if (!objs) {
+        objs = {};
+        objs.ee = new EventEmitter();
+        objs.sink = new Sink();
+        getGlobalThis()['@podium'] = objs;
     }
 
-    return ee;
+    return objs;
 }
 
 export default class MessageBus {
     constructor() {
-        this.ee = getEventEmitter();
+        const { ee, sink } = getGlobalObjects();
+        this.ee = ee;
+        this.sink = sink;
+    }
+
+    log(channel, topic) {
+        return this.sink.read(channel, topic);
     }
 
     publish(channel, topic, payload) {
         const event = new Event(channel, topic, payload);
         this.ee.emit(event.toKey(), event);
+        this.sink.push(event);
+        return event;
     }
 
     subscribe(channel, topic, listener) {

--- a/lib/Sink.mjs
+++ b/lib/Sink.mjs
@@ -1,0 +1,18 @@
+import { toKey } from './utils';
+
+export default class Sink {
+    constructor() {
+        this.map = new Map();
+    }
+
+    push(event) {
+        // Not actually a stack yet...
+        const stack = this.read(event.channel, event.topic);
+        stack.push(event);
+        this.map.set(event.toKey(), stack);
+    }
+
+    read(channel, topic) {
+        return this.map.get(toKey(channel, topic)) || [];
+    }
+}

--- a/test/MessageBus.test.mjs
+++ b/test/MessageBus.test.mjs
@@ -26,3 +26,17 @@ tap.test('publish() - should invoke listener', t => {
     });
     bus.publish('foo', 'bar', payload);
 });
+
+tap.test('log() - should retrieve earlier events', t => {
+    const channel = 'foo';
+    const topic = 'foo';
+
+    const payload1 = 'payload1';
+    const payload2 = { a: 'b' };
+
+    const event1 = bus.publish(channel, topic, payload1);
+    const event2 = bus.publish(channel, topic, payload2);
+
+    t.same(bus.log(channel, topic), [event1, event2]);
+    t.end();
+});

--- a/test/Sink.test.mjs
+++ b/test/Sink.test.mjs
@@ -1,0 +1,24 @@
+import tap from 'tap';
+import Sink from '../lib/Sink';
+
+let sink;
+
+tap.beforeEach(end => {
+    sink = new Sink();
+    end();
+});
+
+tap.test('read() - should be a function', t => {
+    t.ok(typeof sink.read === 'function');
+    t.end();
+});
+
+tap.test('read() - should initially return an empty array', t => {
+    t.same(sink.read('foo', 'bar'), []);
+    t.end();
+});
+
+tap.test('push() - should be a function', t => {
+    t.ok(typeof sink.push === 'function');
+    t.end();
+});


### PR DESCRIPTION
This pull request adds a proof of concept of a sink-like. The idea is that you should be able to retrieve earlier events. Of course the sink won't be able to keep every event, so the next step is to limit it at something like 10 per channel/topic.