### PR TITLE
limit the number of kept events

### DIFF
--- a/lib/MessageBus.mjs
+++ b/lib/MessageBus.mjs
@@ -32,8 +32,18 @@ export default class MessageBus {
         this.sink = sink;
     }
 
+    /**
+     * Get the latest events, newest first
+     */
     log(channel, topic) {
-        return this.sink.read(channel, topic);
+        return this.sink.log(channel, topic);
+    }
+
+    /**
+     * Get the latest event
+     */
+    peek(channel, topic) {
+        return this.sink.peek(channel, topic);
     }
 
     publish(channel, topic, payload) {

--- a/lib/Queue.mjs
+++ b/lib/Queue.mjs
@@ -1,0 +1,22 @@
+export default class Queue {
+    constructor(maxLength = 10) {
+        this.maxSize = maxLength;
+        this.array = [];
+    }
+
+    push(item) {
+        // If we are out of room, get rid of the oldest element
+        if (this.array.length >= this.maxSize) {
+            this.array.pop();
+        }
+        this.array.unshift(item);
+    }
+
+    peek() {
+        return this.array[0];
+    }
+
+    toArray() {
+        return this.array.slice();
+    }
+}

--- a/lib/Sink.mjs
+++ b/lib/Sink.mjs
@@ -1,18 +1,26 @@
 import { toKey } from './utils';
+import Queue from './Queue';
 
 export default class Sink {
     constructor() {
         this.map = new Map();
     }
 
-    push(event) {
-        // Not actually a stack yet...
-        const stack = this.read(event.channel, event.topic);
-        stack.push(event);
-        this.map.set(event.toKey(), stack);
+    getQueue(channel, topic) {
+        return this.map.get(toKey(channel, topic)) || new Queue();
     }
 
-    read(channel, topic) {
-        return this.map.get(toKey(channel, topic)) || [];
+    push(event) {
+        const queue = this.getQueue(event.channel, event.topic);
+        queue.push(event);
+        this.map.set(event.toKey(), queue);
+    }
+
+    peek(channel, topic) {
+        return this.getQueue(channel, topic).peek();
+    }
+
+    log(channel, topic) {
+        return this.getQueue(channel, topic).toArray();
     }
 }

--- a/test/MessageBus.test.mjs
+++ b/test/MessageBus.test.mjs
@@ -4,6 +4,9 @@ import MessageBus from '../lib/MessageBus';
 let bus;
 
 tap.beforeEach(end => {
+    // Need to clear the global between tests for a clean slate
+    // eslint-disable-next-line no-undef
+    globalThis['@podium'] = null;
     bus = new MessageBus();
     end();
 });
@@ -27,9 +30,31 @@ tap.test('publish() - should invoke listener', t => {
     bus.publish('foo', 'bar', payload);
 });
 
-tap.test('log() - should retrieve earlier events', t => {
-    const channel = 'foo';
-    const topic = 'foo';
+tap.test('peek() - should initially be empty', t => {
+    t.ok(bus.peek('channel', 'topic') == null);
+    t.end();
+});
+
+tap.test('peek() - should return latest event', t => {
+    const channel = 'channel';
+    const topic = 'topic';
+
+    for (let i = 0; i <= 3; i += 1) {
+        const event = bus.publish(channel, topic, i);
+        t.equal(event, bus.peek(channel, topic));
+    }
+
+    t.end();
+});
+
+tap.test('log() - should initially be empty', t => {
+    t.same(bus.log('channel', 'topic'), []);
+    t.end();
+});
+
+tap.test('log() - should retrieve earlier events, newest first', t => {
+    const channel = 'channel';
+    const topic = 'topic';
 
     const payload1 = 'payload1';
     const payload2 = { a: 'b' };
@@ -37,6 +62,6 @@ tap.test('log() - should retrieve earlier events', t => {
     const event1 = bus.publish(channel, topic, payload1);
     const event2 = bus.publish(channel, topic, payload2);
 
-    t.same(bus.log(channel, topic), [event1, event2]);
+    t.same(bus.log(channel, topic), [event2, event1]);
     t.end();
 });

--- a/test/Sink.test.mjs
+++ b/test/Sink.test.mjs
@@ -8,13 +8,13 @@ tap.beforeEach(end => {
     end();
 });
 
-tap.test('read() - should be a function', t => {
-    t.ok(typeof sink.read === 'function');
+tap.test('log() - should be a function', t => {
+    t.ok(typeof sink.log === 'function');
     t.end();
 });
 
-tap.test('read() - should initially return an empty array', t => {
-    t.same(sink.read('foo', 'bar'), []);
+tap.test('log() - should initially return an empty array', t => {
+    t.same(sink.log('foo', 'bar'), []);
     t.end();
 });
 


### PR DESCRIPTION
This pull request adds a new method, `peek()` to read the latest event for a particular channel/topic combo.

It also limits the number of events we keep a reference to (currently hardcoded at 10). When this threshold is reached we started ejecting the earliest event for a channel/topic.