### PR TITLE
point "main" to dist entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@podium/browser",
   "version": "1.0.0-beta.1",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "license": "MIT",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
rollup with `preservemodules` copies the directory structure. See https://github.com/podium-lib/browser/pull/17