### PR TITLE
Export both ESM and CJS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@podium/browser",
   "version": "1.0.0-beta.2",
-  "main": "dist/src/index.js",
-  "license": "MIT",
   "type": "module",
+  "main": "dist/cjs/src/index.js",
+  "exports": {
+    "import": "dist/esm/src/index.js",
+    "require": "dist/cjs/src/index.js"
+  },
+  "license": "MIT",
   "keywords": [
     "micro services",
     "micro frontend",
@@ -21,6 +25,7 @@
   "homepage": "https://podium-lib.io/",
   "files": [
     "dist",
+    "src",
     "index.d.ts"
   ],
   "types": "index.d.ts",
@@ -29,28 +34,26 @@
     "build": "rollup --config",
     "build:clean": "rimraf dist",
     "test": "tap --no-esm test/*.js",
-    "test:coverage": "npm test -- --cov",
     "lint": "eslint . --ignore-pattern '/dist/'",
     "lint:fix": "eslint --fix . --ignore-pattern '/dist/'",
-    "lint:format": "eslint --fix . --ignore-pattern '/dist/'",
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "eventemitter3": "^4.0.0"
+    "eventemitter3": "4.0.4"
   },
   "devDependencies": {
-    "eslint": "7.1.0",
+    "eslint": "7.2.0",
     "eslint-config-airbnb-base": "14.1.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-import": "2.20.2",
     "eslint-plugin-prettier": "3.1.3",
-    "lint-staged": "10.0.0",
-    "prettier": "2.0.2",
-    "rimraf": "3.0.1",
-    "rollup": "2.0.5",
-    "rollup-plugin-commonjs": "10.1.0",
-    "rollup-plugin-node-resolve": "5.2.0",
-    "tap": "14.10.5"
+    "lint-staged": "10.2.9",
+    "prettier": "2.0.5",
+    "rimraf": "3.0.2",
+    "rollup": "2.13.1",
+    "@rollup/plugin-commonjs": "13.0.0",
+    "@rollup/plugin-node-resolve": "8.0.1",
+    "tap": "14.10.7"
   },
   "lint-staged": {
     "*.js": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,16 @@
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
 
 export default {
     input: 'src/index.js',
-    output: {
-        dir: 'dist',
+    output: [{
+        dir: 'dist/esm',
         format: 'esm',
     },
+    {
+        dir: 'dist/cjs',
+        format: 'cjs',
+    }],
     plugins: [resolve(), commonjs()],
     preserveModules: true,
 };


### PR DESCRIPTION
This makes this module expose both a pre-built CommonJS and ESM version by using the `exports` feature introduced in the latest versions of node.js 12.x and 14.x where ESM is unflagged. This should make it possible to use this module in both an ESM environment and a CommonJS environment without the user having to transpile it in their end.

It works as follow:

When publishing this module there will be two folders where one is a ESM version and the other is a CommonJS version. 

In `package.json` the following is set:

```json
{
  "type": "module",
  "main": "dist/cjs/src/index.js",
  "exports": {
    "import": "dist/esm/src/index.js",
    "require": "dist/cjs/src/index.js"
  }
}
```

The module is flagged as an ESM module by `type: "module"`. When a node.js version supporting ESM is used and used in a ESM, it will use the build defined by `exports.import`. When used in a CommonJS require, it will use the build defined by `exports.require`.

When a node.js version NOT supporting ESM is used, the build defined by `main` is used. This makes this module possible to use in older versions of node and build systems without doing transpiling.