### PR TITLE
Improve hybrid ESM/CommonJS setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@podium/browser",
   "version": "1.1.0",
-  "type": "module",
   "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/src/index.js",
   "exports": {
     "import": "./dist/esm/src/index.js",
     "require": "./dist/cjs/src/index.js"
@@ -31,7 +31,7 @@
   "types": "index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run build:clean && npm run build",
-    "build": "rollup --config",
+    "build": "rollup --config && cp src/package.cjs.json dist/cjs/package.json && cp src/package.esm.json dist/esm/package.json",
     "build:clean": "rimraf dist",
     "test": "tap --no-esm test/*.js",
     "lint": "eslint . --ignore-pattern '/dist/'",

--- a/src/package.cjs.json
+++ b/src/package.cjs.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/package.esm.json
+++ b/src/package.esm.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
By having separate `package.json` files for the ESM and CommonJS
distribution directories which sets the corresponding `type`, it should
work in all situations.

This will for example fix problems where a module you `import` does a
`require` on this module. Here is an example of this problem from a Node
app during building with SSR:

```
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module:
.../node_modules/@podium/browser/dist/cjs/src/index.js.
require() of ES modules is not supported.

require() of .../node_modules/@podium/browser/dist/cjs/src/index.js from <some code>
is an ES module file as it is a .js file whose nearest parent package.json contains
"type": "module" which defines all .js files in that package scope as ES modules.

Instead rename index.js to end in .cjs, change the requiring code to use import(),
or remove "type": "module" from .../node_modules/@podium/browser/package.json.
```

This technique is taken from https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html