### PR TITLE
Restructure dual module type package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ tmp/**/*
 .idea
 .idea/**/*
 coverage
-dist

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "@podium/browser",
   "version": "1.1.0",
   "type": "module",
-  "main": "./dist/cjs/src/index.js",
+  "main": "./dist/index.js",
   "exports": {
-    "import": "./dist/esm/src/index.js",
-    "require": "./dist/cjs/src/index.js"
+    "require": "./dist/index.js",
+    "import": "./src/index.js"
   },
   "license": "MIT",
   "keywords": [
@@ -30,13 +30,11 @@
   ],
   "types": "index.d.ts",
   "scripts": {
-    "prepublishOnly": "npm run build:clean && npm run build",
-    "build": "rollup --config",
-    "build:clean": "rimraf dist",
+    "prepublishOnly": "npm run build",
+    "build": "rollup -c",
     "test": "tap test/*.js",
     "lint": "eslint . --ignore-pattern '/dist/'",
-    "lint:fix": "eslint --fix . --ignore-pattern '/dist/'",
-    "precommit": "lint-staged"
+    "lint:fix": "eslint --fix . --ignore-pattern '/dist/'"
   },
   "dependencies": {
     "eventemitter3": "4.0.7"
@@ -52,20 +50,8 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.24.2",
     "eslint-plugin-prettier": "4.0.0",
-    "lint-staged": "11.1.2",
     "prettier": "2.4.1",
-    "rimraf": "3.0.2",
     "rollup": "2.57.0",
     "tap": "15.0.10"
-  },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix --config ./.eslintrc",
-      "git add"
-    ],
-    "{*.json,*.md,.eslintrc,.prettierrc}": [
-      "prettier --write",
-      "git add"
-    ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,22 +2,17 @@ import { getBabelOutputPlugin } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 
-export default [{
+export default {
     input: 'src/index.js',
-    output: [{
-        dir: 'dist/cjs',
-        format: 'cjs',
-    }],
     plugins: [resolve(), commonjs(), getBabelOutputPlugin({
         presets: ['@babel/preset-env']
     })],
-    preserveModules: true,
-},{
-    input: 'src/index.js',
-    output: [{
-        dir: 'dist/esm',
-        format: 'esm',
-    }],
-    plugins: [resolve(), commonjs()],
-    preserveModules: true,
-}];
+    output: [
+        {
+            exports: 'auto',
+            format: 'cjs',
+            dir: 'dist/',
+            preserveModules: true,
+        }
+    ],
+};


### PR DESCRIPTION
This addresses whats highlighted in #113. Though while looking into this there are a fair amount of rabbits in this rabbit hole.

So; this module is built as an ESM and we transpile the ESM to a CJS build for older versions on pre publish. It is currently making a ESM build where any dependencies is also moved into the build as part of the package. In other words when depending on this package the depender is using build versions, for both ESM and CJS, of this module.

Issue one here is that the folder which the common js build are stored in must be set to `type` equaling `commonjs`. This is the main issue in #113.

The second issue is that the ESM build also fails for the following reason: when we're building the file structure of the module and its dependencies is somewhat kept. To do so, the build does get a directory tree structure which holds any dependencies this modules depend upon (it depends on one module other module). All dependencies are also converted to ESM. 
In this tree structure there will then be a `node_modules` folder which is Rollups way of structuring files to avoid any file collision and this structure we do not have any control of. Though, the troublesome part here is that node.js looks for `node_modules` folder and if it finds one and there is no `package.json` in it, it assume everything in it is CJS fils. Though, they are not because we're transpiling them to ESM. And, there is no way in Rollup to alter the `node_modules` folder, set a different file extension (*.mjs) or add a `package.json` in this folder.

To deal with the second issue, this PR changes the build from only generating CJS and then exporting the source files for ESM.